### PR TITLE
Consistent B field between numbers of MPI processes

### DIFF
--- a/prob/torus/problem.c
+++ b/prob/torus/problem.c
@@ -154,9 +154,9 @@ void init(struct GridGeom *G, struct FluidState *S)
 
       S->P[RHO][k][j][i] = rho;
       if (rho > rhomax) rhomax = rho;
+      if (u > umax && r > rin) umax = u;
       u *= (1. + u_jitter * (gsl_rng_uniform(rng) - 0.5));
       S->P[UU][k][j][i] = u;
-      if (u > umax && r > rin) umax = u;
       S->P[U1][k][j][i] = 0.;
       S->P[U2][k][j][i] = 0.;
       S->P[U3][k][j][i] = up;


### PR DESCRIPTION
It was cute and technically accurate to key the maximum internal energy for B field normalization off the "jittered" randomized value of U.  But it's much more useful that B be normalized consistently. Waiting on my own tests that this fixes #12.