### PR TITLE
add abort feature

### DIFF
--- a/core/decs.h
+++ b/core/decs.h
@@ -158,11 +158,16 @@
 #define MINKOWSKI (0)
 #define MKS       (1)
 
+// abort versus regular IO
+#define IO_REGULAR (1)
+#define IO_ABORT (2)
+
 // Diagnostic calls
 #define DIAG_INIT  (0)
 #define DIAG_DUMP  (1)
 #define DIAG_LOG   (2)
 #define DIAG_FINAL (3)
+#define DIAG_ABORT (4)
 
 // Failure modes
 // TODO find+eliminate uses
@@ -440,6 +445,7 @@ void flux_ct(struct FluidFlux *F);
 // io.c
 void init_io();
 void dump(struct GridGeom *G, struct FluidState *S);
+void dump_backend(struct GridGeom *G, struct FluidState *S, int type);
 void dump_grid(struct GridGeom *G);
 
 // metric.c
@@ -524,6 +530,7 @@ void reconstruct(struct FluidState *S, GridPrim Pl, GridPrim Pr, int dir);
 
 // restart.c
 void restart_write(struct FluidState *S);
+void restart_write_backend(struct FluidState *S, int type);
 void restart_read(char *fname, struct FluidState *S);
 int restart_init(struct GridGeom *G, struct FluidState *S);
 

--- a/core/diag.c
+++ b/core/diag.c
@@ -133,6 +133,10 @@ void diag(struct GridGeom *G, struct FluidState *S, int call_code)
     dump_cnt++;
   }
 
+  if (call_code == DIAG_ABORT) {
+    dump_backend(G, S, IO_ABORT);
+  }
+
   if (call_code == DIAG_INIT || call_code == DIAG_LOG ||
       call_code == DIAG_FINAL) {
     double mdot_all = mpi_reduce(mdot);

--- a/core/io.c
+++ b/core/io.c
@@ -27,6 +27,11 @@
 
 void dump(struct GridGeom *G, struct FluidState *S)
 {
+  dump_backend(G, S, IO_REGULAR);
+}
+
+void dump_backend(struct GridGeom *G, struct FluidState *S, int type)
+{
   timer_start(TIMER_IO);
 
   static GridDouble *data;
@@ -48,7 +53,12 @@ void dump(struct GridGeom *G, struct FluidState *S)
   //Don't re-dump the grid after a restart
   if (dump_cnt == 0) dump_grid(G);
 
-  sprintf(fname, "dumps/dump_%08d.h5", dump_cnt);
+  if (type == IO_REGULAR) {
+    sprintf(fname, "dumps/dump_%08d.h5", dump_cnt);
+  } else if (type == IO_ABORT) {
+    sprintf(fname, "dumps/dump_abort.h5");    
+  }
+
   if(mpi_io_proc()) fprintf(stdout, "DUMP %s\n", fname);
 
   hdf5_create(fname);

--- a/core/main.c
+++ b/core/main.c
@@ -127,7 +127,6 @@ int main(int argc, char *argv[])
   while (t < tf) {
 
     // Handle abort case
-    chdir(".");
     if ( access(abort_fname, F_OK) != -1 ) {
       if (mpi_io_proc()) {
         fprintf(stdout, "\nFound 'abort' file. Quitting now.\n\n");

--- a/core/restart.c
+++ b/core/restart.c
@@ -21,7 +21,13 @@ static hsize_t fcount[] = {NVAR, N3, N2, N1};
 static hsize_t mdims[] = {NVAR, N3+2*NG, N2+2*NG, N1+2*NG};
 static hsize_t mstart[] = {0, NG, NG, NG};
 
-void restart_write(struct FluidState *S)
+
+void restart_write(struct FluidState *S) 
+{
+  restart_write_backend(S, IO_REGULAR);
+}
+
+void restart_write_backend(struct FluidState *S, int type)
 {
   timer_start(TIMER_RESTART);
 
@@ -29,7 +35,12 @@ void restart_write(struct FluidState *S)
   restart_id++;
 
   char fname[STRLEN];
-  sprintf(fname, "restarts/restart_%08d.h5", restart_id);
+
+  if (type == IO_REGULAR) {
+    sprintf(fname, "restarts/restart_%08d.h5", restart_id);
+  } else if (type == IO_ABORT) {
+    sprintf(fname, "restarts/restart_abort.h5");
+  }
 
   hdf5_create(fname);
 


### PR DESCRIPTION
iharm3d will abort its run (and write restarts/restart_abort.h5 and dumps/dump_abort.h5) if it finds a file named "abort" in its running directory.

**This commit should *not* be merged until lead developers have a discussion!**

In its current form, iharm3d does not seem to notice files created from different computers (on networked drives). A specific example of this is:

1. run iharm3d on bh28
2. create file "abort" in run directory of iharm3d from bh28  ->  iharm3d stops

1. run iharm3d on bh28
2. create file "abort" in run directory of iharm3d *from bh*  ->  iharm3d does not stop
3. wait  ->  iharm3d does not stop
4. execute "ls" *from bh*  ->  iharm3d does not stop, file "abort" shows up in ls
5. execute "ls" *from bh28*  ->  iharm3d stops, file "abort" shows up in ls

Note that calling ```chdir(".");``` doesn't work, and checking whether ```fopen(...)``` is successful doesn't work either.