### PR TITLE
Feature/electron models

### DIFF
--- a/core/decs.h
+++ b/core/decs.h
@@ -36,7 +36,7 @@
       COMPILE-TIME PARAMETERS :
 *******************************************************************************/
 
-#define VERSION "iharm-alpha-3.6"
+#define VERSION "iharm-alpha-3.7"
 
 // Number of active zones on each MPI process
 #define N1       (N1TOT/N1CPU)

--- a/core/decs.h
+++ b/core/decs.h
@@ -140,7 +140,7 @@
 #define KEL3 (12) // Sharma
 #define NVAR (13)
 #else
-#define KEL  (9)
+#define KEL0  (9)
 #define NVAR (10)
 #endif
 #else

--- a/core/decs.h
+++ b/core/decs.h
@@ -132,9 +132,17 @@
 #define B2  (6)
 #define B3  (7)
 #if ELECTRONS
-#define KEL  (8)
-#define KTOT (9)
+#define KTOT (8)
+#if ALLMODELS     // Nested if statement for ALLMODELS run
+#define KEL0 (9)  // Kawazura
+#define KEL1 (10) // Werner
+#define KEL2 (11) // Rowan
+#define KEL3 (12) // Sharma
+#define NVAR (13)
+#else
+#define KEL  (9)
 #define NVAR (10)
+#endif
 #else
 #define NVAR (8)
 #endif

--- a/core/electrons.c
+++ b/core/electrons.c
@@ -11,14 +11,18 @@
 #if ELECTRONS
 
 // TODO put these in options with a default in decs.h
-#define HOWES 0
-#define KAWAZURA 1
-#define CONSTANT 3
+// Defined as in decs.h, CONSTANT not included in ALLMODELS version
+#define KAWAZURA  9
+#define WERNER    10
+#define ROWAN     11
+#define SHARMA    12
+#define CONSTANT 5
 #define FE_MODEL KAWAZURA
 
 void fixup_electrons_1zone(struct FluidState *S, int i, int j, int k);
 void heat_electrons_1zone(struct GridGeom *G, struct FluidState *Sh, struct FluidState *S, int i, int j, int k);
 double get_fel(struct GridGeom *G, struct FluidState *S, int i, int j, int k);
+double get_fels(struct GridGeom *G, struct FluidState *S, int i, int j, int k, int model);
 
 void init_electrons(struct GridGeom *G, struct FluidState *S)
 {
@@ -28,7 +32,15 @@ void init_electrons(struct GridGeom *G, struct FluidState *S)
 
     // Initialize entropies
     S->P[KTOT][k][j][i] = (gam-1.)*S->P[UU][k][j][i]*pow(S->P[RHO][k][j][i],-gam);
+
+    // Initialize different models' entropies
+    #if ALLMODELS
+    for (int idx = KEL0; idx < NVAR ; idx++) {
+      S->P[idx][k][j][i] = (game-1.)*uel*pow(S->P[RHO][k][j][i],-game);
+    }
+    #else
     S->P[KEL][k][j][i] = (game-1.)*uel*pow(S->P[RHO][k][j][i],-game);
+    #endif
   }
 
   // Necessary?  Usually called right afterward
@@ -55,9 +67,16 @@ inline void heat_electrons_1zone(struct GridGeom *G, struct FluidState *Ss, stru
 
   //double uel = 1./(game-1.)*S->P[KEL][k][j][i]*pow(S->P[RHO][k][j][i],game);
 
+  // Evolve different models' entropies
+  #if ALLMODELS
+  for (int idx = KEL0; idx < NVAR ; idx++) {
+    double fel = get_fels(G, Ss, i, j, k, idx);
+    Sf->P[idx][k][j][i] += (game-1.)/(gam-1.)*pow(Ss->P[RHO][k][j][i],gam-game)*fel*(kHarm - Sf->P[KTOT][k][j][i]);
+  }
+  #else
   double fel = get_fel(G, Ss, i, j, k);
-
   Sf->P[KEL][k][j][i] += (game-1.)/(gam-1.)*pow(Ss->P[RHO][k][j][i],gam-game)*fel*(kHarm - Sf->P[KTOT][k][j][i]);
+  #endif
 
   // TODO bhlight calculates Qvisc here instead of this
   //double ugHat = S->P[KTOT][k][j][i]*pow(S->P[RHO][k][j][i],gam)/(gam-1.);
@@ -73,8 +92,62 @@ inline void heat_electrons_1zone(struct GridGeom *G, struct FluidState *Ss, stru
   Sf->P[KTOT][k][j][i] = kHarm;
 }
 
+// New function for ALLMODELS runs.
+#if ALLMODELS
+inline double get_fels(struct GridGeom *G, struct FluidState *S, int i, int j, int k, int model)
+{
+  get_state(G, S, i, j, k, CENT);
+  double bsq = bsq_calc(S, i, j, k);
+  double fel = 0.0;
+if (model == KAWAZURA) {
+  double Tpr = (gam-1.)*S->P[UU][k][j][i]/S->P[RHO][k][j][i];
+  double uel = 1./(game-1.)*S->P[model][k][j][i]*pow(S->P[RHO][k][j][i],game);
+  double Tel = (game-1.)*uel/S->P[RHO][k][j][i];
+  if(Tel <= 0.) Tel = SMALL;
+  if(Tpr <= 0.) Tpr = SMALL;
+
+  double Trat = fabs(Tpr/Tel);
+  double pres = S->P[RHO][k][j][i]*Tpr; // Proton pressure
+  double beta = pres/bsq*2;
+  if(beta > 1.e20) beta = 1.e20;
+  
+  double QiQe = 35./(1. + pow(beta/15.,-1.4)*exp(-0.1/Trat));
+  fel = 1./(1. + QiQe);
+} else if (model == WERNER) {
+  double sigma = bsq/S->P[RHO][k][j][i];
+  fel = 0.25*(1+pow(((sigma/5.)/(2+(sigma/5.))), .5));
+} else if (model == ROWAN) {
+  double pres = (gam-1.)*S->P[UU][k][j][i]; // Proton pressure
+  double beta = pres/bsq*2;
+  double sigma = bsq/(S->P[RHO][k][j][i]+S->P[UU][k][j][i]+pres);
+  double betamax = 0.25/sigma;
+  fel = 0.5*exp(-pow(1-beta/betamax, 3.3)/(1+1.2*pow(sigma, 0.7)));
+} else if (model == SHARMA) {
+  double Tpr = (gam-1.)*S->P[UU][k][j][i]/S->P[RHO][k][j][i];
+  double uel = 1./(game-1.)*S->P[model][k][j][i]*pow(S->P[RHO][k][j][i],game);
+  double Tel = (game-1.)*uel/S->P[RHO][k][j][i];
+  if(Tel <= 0.) Tel = SMALL;
+  if(Tpr <= 0.) Tpr = SMALL;
+
+  double Trat = fabs(Tel/Tpr);
+  fel = 0.33 * pow(Trat, 0.5);
+}
+
+#if SUPPRESS_HIGHB_HEAT
+  if(bsq/S->P[RHO][k][j][i] > 1.) fel = 0;
+#endif
+
+  return fel;
+}
+//////////////////////////////////
+#else
+//////////////////////////////////
 inline double get_fel(struct GridGeom *G, struct FluidState *S, int i, int j, int k)
 {
+  get_state(G, S, i, j, k, CENT);
+  double bsq = bsq_calc(S, i, j, k);
+
+#if FE_MODEL == KAWAZURA
   double Tpr = (gam-1.)*S->P[UU][k][j][i]/S->P[RHO][k][j][i];
   double uel = 1./(game-1.)*S->P[KEL][k][j][i]*pow(S->P[RHO][k][j][i],game);
   double Tel = (game-1.)*uel/S->P[RHO][k][j][i];
@@ -82,30 +155,30 @@ inline double get_fel(struct GridGeom *G, struct FluidState *S, int i, int j, in
   if(Tpr <= 0.) Tpr = SMALL;
 
   double Trat = fabs(Tpr/Tel);
-
   double pres = S->P[RHO][k][j][i]*Tpr; // Proton pressure
-
-  //TODO can I prevent this call?
-  get_state(G, S, i, j, k, CENT);
-  double bsq = bsq_calc(S, i, j, k);
-
   double beta = pres/bsq*2;
   if(beta > 1.e20) beta = 1.e20;
-
-#if FE_MODEL == HOWES
-  double logTrat = log10(Trat);
-  double mbeta = 2. - 0.2*logTrat;
-
-  double c1 = 0.92;
-  double c2 = (Trat <= 1.) ? 1.6/Trat : 1.2/Trat;
-  double c3 = (Trat <= 1.) ? 18. + 5.*logTrat : 18.;
-
-  double beta_pow = pow(beta,mbeta);
-  double qrat = c1*(c2*c2+beta_pow)/(c3*c3 + beta_pow)*exp(-1./beta)*pow(MP/ME*Trat,.5);
-  double fel = 1./(1. + qrat);
-#elif FE_MODEL == KAWAZURA
+  
   double QiQe = 35./(1. + pow(beta/15.,-1.4)*exp(-0.1/Trat));
   double fel = 1./(1. + QiQe);
+#elif FE_MODEL == WERNER
+  double sigma = bsq/S->P[RHO][k][j][i];
+  double fel = 0.25*(1+pow(((sigma/5.)/(2+(sigma/5.))), .5));
+#elif FE_MODEL == ROWAN
+  double pres = (gam-1.)*S->P[UU][k][j][i]; // Proton pressure
+  double beta = pres/bsq*2;
+  double sigma = bsq/(S->P[RHO][k][j][i]+S->P[UU][k][j][i]+pres);
+  double betamax = 0.25/sigma;
+  double fel = 0.5*exp(-pow(1-beta/betamax, 3.3)/(1+1.2*pow(sigma, 0.7)));
+#elif FE_MODEL == SHARMA
+  double Tpr = (gam-1.)*S->P[UU][k][j][i]/S->P[RHO][k][j][i];
+  double uel = 1./(game-1.)*S->P[model][k][j][i]*pow(S->P[RHO][k][j][i],game);
+  double Tel = (game-1.)*uel/S->P[RHO][k][j][i];
+  if(Tel <= 0.) Tel = SMALL;
+  if(Tpr <= 0.) Tpr = SMALL;
+
+  double Trat = fabs(Tel/Tpr);
+  double fel = 0.33 * pow(Trat, 0.5);
 #elif FE_MODEL == CONSTANT
   double fel = fel0;
 #endif
@@ -116,6 +189,7 @@ inline double get_fel(struct GridGeom *G, struct FluidState *S, int i, int j, in
 
   return fel;
 }
+#endif
 
 void fixup_electrons(struct FluidState *S)
 {
@@ -131,9 +205,17 @@ void fixup_electrons(struct FluidState *S)
 
 inline void fixup_electrons_1zone(struct FluidState *S, int i, int j, int k)
 {
+
   double kelmax = S->P[KTOT][k][j][i]*pow(S->P[RHO][k][j][i],gam-game)/(tptemin*(gam-1.)/(gamp-1.) + (gam-1.)/(game-1.));
   double kelmin = S->P[KTOT][k][j][i]*pow(S->P[RHO][k][j][i],gam-game)/(tptemax*(gam-1.)/(gamp-1.) + (gam-1.)/(game-1.));
 
+  #if ALLMODELS
+  for (int idx = KEL0; idx < NVAR ; idx++) {
+    if (isnan(S->P[idx][k][j][i])) S->P[idx][k][j][i] = kelmin;
+    S->P[idx][k][j][i] = MY_MAX(S->P[idx][k][j][i], kelmin);
+    S->P[idx][k][j][i] = MY_MIN(S->P[idx][k][j][i], kelmax);
+  }
+  #else
   // Replace NANs with cold electrons
   if (isnan(S->P[KEL][k][j][i])) S->P[KEL][k][j][i] = kelmin;
 
@@ -142,6 +224,7 @@ inline void fixup_electrons_1zone(struct FluidState *S, int i, int j, int k)
 
   // Enforce minimum Tp/Te
   S->P[KEL][k][j][i] = MY_MIN(S->P[KEL][k][j][i], kelmax);
+  #endif
 }
 #endif // ELECTRONS
 

--- a/core/electrons.c
+++ b/core/electrons.c
@@ -89,6 +89,7 @@ inline double get_fels(struct GridGeom *G, struct FluidState *S, int i, int j, i
   double bsq = bsq_calc(S, i, j, k);
   double fel = 0.0;
 if (model == KAWAZURA) {
+	// Equation (2) in http://www.pnas.org/lookup/doi/10.1073/pnas.1812491116
   double Tpr = (gamp-1.)*S->P[UU][k][j][i]/S->P[RHO][k][j][i];
   double uel = 1./(game-1.)*S->P[model][k][j][i]*pow(S->P[RHO][k][j][i],game);
   double Tel = (game-1.)*uel/S->P[RHO][k][j][i];
@@ -103,9 +104,11 @@ if (model == KAWAZURA) {
   double QiQe = 35./(1. + pow(beta/15.,-1.4)*exp(-0.1/Trat));
   fel = 1./(1. + QiQe);
 } else if (model == WERNER) {
+	// Equation (3) in http://academic.oup.com/mnras/article/473/4/4840/4265350
   double sigma = bsq/S->P[RHO][k][j][i];
   fel = 0.25*(1+pow(((sigma/5.)/(2+(sigma/5.))), .5));
 } else if (model == ROWAN) {
+	// Equation (34) in https://iopscience.iop.org/article/10.3847/1538-4357/aa9380
   double pres = (gamp-1.)*S->P[UU][k][j][i]; // Proton pressure
   double pg = (gam-1)*S->P[UU][k][j][i];
   double beta = pres/bsq*2;
@@ -113,6 +116,7 @@ if (model == KAWAZURA) {
   double betamax = 0.25/sigma;
   fel = 0.5*exp(-pow(1-beta/betamax, 3.3)/(1+1.2*pow(sigma, 0.7)));
 } else if (model == SHARMA) {
+	// Equation for \delta on  pg. 719 (Section 4) in https://iopscience.iop.org/article/10.1086/520800
   double Tpr = (gamp-1.)*S->P[UU][k][j][i]/S->P[RHO][k][j][i];
   double uel = 1./(game-1.)*S->P[model][k][j][i]*pow(S->P[RHO][k][j][i],game);
   double Tel = (game-1.)*uel/S->P[RHO][k][j][i];

--- a/core/electrons.c
+++ b/core/electrons.c
@@ -12,16 +12,15 @@
 
 // TODO put these in options with a default in decs.h
 // Defined as in decs.h, CONSTANT not included in ALLMODELS version
+// KAWAZURA is run by default if ALLMODELS=0 
 #define KAWAZURA  9
 #define WERNER    10
 #define ROWAN     11
 #define SHARMA    12
-#define CONSTANT 5
-#define FE_MODEL KAWAZURA
+#define CONSTANT 5 //tbh, this is never considered 
 
 void fixup_electrons_1zone(struct FluidState *S, int i, int j, int k);
 void heat_electrons_1zone(struct GridGeom *G, struct FluidState *Sh, struct FluidState *S, int i, int j, int k);
-double get_fel(struct GridGeom *G, struct FluidState *S, int i, int j, int k);
 double get_fels(struct GridGeom *G, struct FluidState *S, int i, int j, int k, int model);
 
 void init_electrons(struct GridGeom *G, struct FluidState *S)
@@ -33,14 +32,10 @@ void init_electrons(struct GridGeom *G, struct FluidState *S)
     // Initialize entropies
     S->P[KTOT][k][j][i] = (gam-1.)*S->P[UU][k][j][i]*pow(S->P[RHO][k][j][i],-gam);
 
-    // Initialize different models' entropies
-    #if ALLMODELS
+    // Initialize model entropy(ies)
     for (int idx = KEL0; idx < NVAR ; idx++) {
       S->P[idx][k][j][i] = (game-1.)*uel*pow(S->P[RHO][k][j][i],-game);
     }
-    #else
-    S->P[KEL][k][j][i] = (game-1.)*uel*pow(S->P[RHO][k][j][i],-game);
-    #endif
   }
 
   // Necessary?  Usually called right afterward
@@ -67,16 +62,11 @@ inline void heat_electrons_1zone(struct GridGeom *G, struct FluidState *Ss, stru
 
   //double uel = 1./(game-1.)*S->P[KEL][k][j][i]*pow(S->P[RHO][k][j][i],game);
 
-  // Evolve different models' entropies
-  #if ALLMODELS
+  // Evolve model entropy(ies)
   for (int idx = KEL0; idx < NVAR ; idx++) {
     double fel = get_fels(G, Ss, i, j, k, idx);
     Sf->P[idx][k][j][i] += (game-1.)/(gam-1.)*pow(Ss->P[RHO][k][j][i],gam-game)*fel*(kHarm - Sf->P[KTOT][k][j][i]);
   }
-  #else
-  double fel = get_fel(G, Ss, i, j, k);
-  Sf->P[KEL][k][j][i] += (game-1.)/(gam-1.)*pow(Ss->P[RHO][k][j][i],gam-game)*fel*(kHarm - Sf->P[KTOT][k][j][i]);
-  #endif
 
   // TODO bhlight calculates Qvisc here instead of this
   //double ugHat = S->P[KTOT][k][j][i]*pow(S->P[RHO][k][j][i],gam)/(gam-1.);
@@ -93,14 +83,13 @@ inline void heat_electrons_1zone(struct GridGeom *G, struct FluidState *Ss, stru
 }
 
 // New function for ALLMODELS runs.
-#if ALLMODELS
 inline double get_fels(struct GridGeom *G, struct FluidState *S, int i, int j, int k, int model)
 {
   get_state(G, S, i, j, k, CENT);
   double bsq = bsq_calc(S, i, j, k);
   double fel = 0.0;
 if (model == KAWAZURA) {
-  double Tpr = (gam-1.)*S->P[UU][k][j][i]/S->P[RHO][k][j][i];
+  double Tpr = (gamp-1.)*S->P[UU][k][j][i]/S->P[RHO][k][j][i];
   double uel = 1./(game-1.)*S->P[model][k][j][i]*pow(S->P[RHO][k][j][i],game);
   double Tel = (game-1.)*uel/S->P[RHO][k][j][i];
   if(Tel <= 0.) Tel = SMALL;
@@ -117,20 +106,22 @@ if (model == KAWAZURA) {
   double sigma = bsq/S->P[RHO][k][j][i];
   fel = 0.25*(1+pow(((sigma/5.)/(2+(sigma/5.))), .5));
 } else if (model == ROWAN) {
-  double pres = (gam-1.)*S->P[UU][k][j][i]; // Proton pressure
+  double pres = (gamp-1.)*S->P[UU][k][j][i]; // Proton pressure
+  double pg = (gam-1)*S->P[UU][k][j][i];
   double beta = pres/bsq*2;
-  double sigma = bsq/(S->P[RHO][k][j][i]+S->P[UU][k][j][i]+pres);
+  double sigma = bsq/(S->P[RHO][k][j][i]+S->P[UU][k][j][i]+pg);
   double betamax = 0.25/sigma;
   fel = 0.5*exp(-pow(1-beta/betamax, 3.3)/(1+1.2*pow(sigma, 0.7)));
 } else if (model == SHARMA) {
-  double Tpr = (gam-1.)*S->P[UU][k][j][i]/S->P[RHO][k][j][i];
+  double Tpr = (gamp-1.)*S->P[UU][k][j][i]/S->P[RHO][k][j][i];
   double uel = 1./(game-1.)*S->P[model][k][j][i]*pow(S->P[RHO][k][j][i],game);
   double Tel = (game-1.)*uel/S->P[RHO][k][j][i];
   if(Tel <= 0.) Tel = SMALL;
   if(Tpr <= 0.) Tpr = SMALL;
 
-  double Trat = fabs(Tel/Tpr);
-  fel = 0.33 * pow(Trat, 0.5);
+  double Trat_inv = fabs(Tel/Tpr); //Inverse of the temperature ratio in KAWAZURA
+  double QeQi = 0.33 * pow(Trat_inv, 0.5);
+	fel = 1./(1.+1./QeQi);
 }
 
 #if SUPPRESS_HIGHB_HEAT
@@ -139,57 +130,6 @@ if (model == KAWAZURA) {
 
   return fel;
 }
-//////////////////////////////////
-#else
-//////////////////////////////////
-inline double get_fel(struct GridGeom *G, struct FluidState *S, int i, int j, int k)
-{
-  get_state(G, S, i, j, k, CENT);
-  double bsq = bsq_calc(S, i, j, k);
-
-#if FE_MODEL == KAWAZURA
-  double Tpr = (gam-1.)*S->P[UU][k][j][i]/S->P[RHO][k][j][i];
-  double uel = 1./(game-1.)*S->P[KEL][k][j][i]*pow(S->P[RHO][k][j][i],game);
-  double Tel = (game-1.)*uel/S->P[RHO][k][j][i];
-  if(Tel <= 0.) Tel = SMALL;
-  if(Tpr <= 0.) Tpr = SMALL;
-
-  double Trat = fabs(Tpr/Tel);
-  double pres = S->P[RHO][k][j][i]*Tpr; // Proton pressure
-  double beta = pres/bsq*2;
-  if(beta > 1.e20) beta = 1.e20;
-  
-  double QiQe = 35./(1. + pow(beta/15.,-1.4)*exp(-0.1/Trat));
-  double fel = 1./(1. + QiQe);
-#elif FE_MODEL == WERNER
-  double sigma = bsq/S->P[RHO][k][j][i];
-  double fel = 0.25*(1+pow(((sigma/5.)/(2+(sigma/5.))), .5));
-#elif FE_MODEL == ROWAN
-  double pres = (gam-1.)*S->P[UU][k][j][i]; // Proton pressure
-  double beta = pres/bsq*2;
-  double sigma = bsq/(S->P[RHO][k][j][i]+S->P[UU][k][j][i]+pres);
-  double betamax = 0.25/sigma;
-  double fel = 0.5*exp(-pow(1-beta/betamax, 3.3)/(1+1.2*pow(sigma, 0.7)));
-#elif FE_MODEL == SHARMA
-  double Tpr = (gam-1.)*S->P[UU][k][j][i]/S->P[RHO][k][j][i];
-  double uel = 1./(game-1.)*S->P[model][k][j][i]*pow(S->P[RHO][k][j][i],game);
-  double Tel = (game-1.)*uel/S->P[RHO][k][j][i];
-  if(Tel <= 0.) Tel = SMALL;
-  if(Tpr <= 0.) Tpr = SMALL;
-
-  double Trat = fabs(Tel/Tpr);
-  double fel = 0.33 * pow(Trat, 0.5);
-#elif FE_MODEL == CONSTANT
-  double fel = fel0;
-#endif
-
-#if SUPPRESS_HIGHB_HEAT
-  if(bsq/S->P[RHO][k][j][i] > 1.) fel = 0;
-#endif
-
-  return fel;
-}
-#endif
 
 void fixup_electrons(struct FluidState *S)
 {
@@ -209,22 +149,15 @@ inline void fixup_electrons_1zone(struct FluidState *S, int i, int j, int k)
   double kelmax = S->P[KTOT][k][j][i]*pow(S->P[RHO][k][j][i],gam-game)/(tptemin*(gam-1.)/(gamp-1.) + (gam-1.)/(game-1.));
   double kelmin = S->P[KTOT][k][j][i]*pow(S->P[RHO][k][j][i],gam-game)/(tptemax*(gam-1.)/(gamp-1.) + (gam-1.)/(game-1.));
 
-  #if ALLMODELS
+  // Replace NANs with cold electrons
   for (int idx = KEL0; idx < NVAR ; idx++) {
     if (isnan(S->P[idx][k][j][i])) S->P[idx][k][j][i] = kelmin;
+	// Enforce maximum Tp/Te
     S->P[idx][k][j][i] = MY_MAX(S->P[idx][k][j][i], kelmin);
+	// Enforce minimum Tp/Te
     S->P[idx][k][j][i] = MY_MIN(S->P[idx][k][j][i], kelmax);
   }
-  #else
-  // Replace NANs with cold electrons
-  if (isnan(S->P[KEL][k][j][i])) S->P[KEL][k][j][i] = kelmin;
 
-  // Enforce maximum Tp/Te
-  S->P[KEL][k][j][i] = MY_MAX(S->P[KEL][k][j][i], kelmin);
-
-  // Enforce minimum Tp/Te
-  S->P[KEL][k][j][i] = MY_MIN(S->P[KEL][k][j][i], kelmax);
-  #endif
 }
 #endif // ELECTRONS
 

--- a/core/io.c
+++ b/core/io.c
@@ -43,7 +43,7 @@ void dump_backend(struct GridGeom *G, struct FluidState *S, int type)
                             "KTOT", "KEL0", "KEL1", "KEL2", "KEL3"};
   #else
   const char varNames[NVAR][HDF_STR_LEN] = {"RHO", "UU", "U1", "U2", "U3", "B1", "B2", "B3",
-                            "KTOT", "KEL"};
+                            "KTOT", "KEL0"};
   #endif
   #else
   const char varNames[NVAR][HDF_STR_LEN] = {"RHO", "UU", "U1", "U2", "U3", "B1", "B2", "B3"}; //Reserve some extra

--- a/core/io.c
+++ b/core/io.c
@@ -38,8 +38,13 @@ void dump_backend(struct GridGeom *G, struct FluidState *S, int type)
   char fname[80];
 
   #if ELECTRONS
+  #if ALLMODELS
   const char varNames[NVAR][HDF_STR_LEN] = {"RHO", "UU", "U1", "U2", "U3", "B1", "B2", "B3",
-                            "KEL", "KTOT"};
+                            "KTOT", "KEL0", "KEL1", "KEL2", "KEL3"};
+  #else
+  const char varNames[NVAR][HDF_STR_LEN] = {"RHO", "UU", "U1", "U2", "U3", "B1", "B2", "B3",
+                            "KTOT", "KEL"};
+  #endif
   #else
   const char varNames[NVAR][HDF_STR_LEN] = {"RHO", "UU", "U1", "U2", "U3", "B1", "B2", "B3"}; //Reserve some extra
   #endif

--- a/core/phys.c
+++ b/core/phys.c
@@ -54,13 +54,9 @@ void prim_to_flux(struct GridGeom *G, struct FluidState *S, int i, int j, int k,
                       S->bcon[dir][k][j][i]*S->ucon[3][k][j][i];
 
 #if ELECTRONS
-#if ALLMODELS
   for (int idx = KEL0; idx < NVAR ; idx++) {
     flux[idx][k][j][i] = flux[RHO][k][j][i]*S->P[idx][k][j][i];
   }
-#elif
-  flux[KEL][k][j][i] = flux[RHO][k][j][i]*S->P[KEL][k][j][i];
-#endif
   flux[KTOT][k][j][i] = flux[RHO][k][j][i]*S->P[KTOT][k][j][i];
 #endif
 
@@ -107,13 +103,9 @@ void prim_to_flux_vec(struct GridGeom *G, struct FluidState *S, int dir, int loc
 #pragma omp for collapse(3)
   ZSLOOP(kstart, kstop, jstart, jstop, istart, istop) {
     // RHO already includes a factor of gdet!
-    #if ALLMODELS
     for (int idx = KEL0; idx < NVAR ; idx++) {
       flux[idx][k][j][i] = flux[RHO][k][j][i]*S->P[idx][k][j][i];
     }
-    #elif
-    flux[KEL][k][j][i] = flux[RHO][k][j][i]*S->P[KEL][k][j][i];
-    #endif
     flux[KTOT][k][j][i] = flux[RHO][k][j][i]*S->P[KTOT][k][j][i];
   }
 #endif

--- a/core/phys.c
+++ b/core/phys.c
@@ -54,7 +54,13 @@ void prim_to_flux(struct GridGeom *G, struct FluidState *S, int i, int j, int k,
                       S->bcon[dir][k][j][i]*S->ucon[3][k][j][i];
 
 #if ELECTRONS
+#if ALLMODELS
+  for (int idx = KEL0; idx < NVAR ; idx++) {
+    flux[idx][k][j][i] = flux[RHO][k][j][i]*S->P[idx][k][j][i];
+  }
+#elif
   flux[KEL][k][j][i] = flux[RHO][k][j][i]*S->P[KEL][k][j][i];
+#endif
   flux[KTOT][k][j][i] = flux[RHO][k][j][i]*S->P[KTOT][k][j][i];
 #endif
 
@@ -101,7 +107,13 @@ void prim_to_flux_vec(struct GridGeom *G, struct FluidState *S, int dir, int loc
 #pragma omp for collapse(3)
   ZSLOOP(kstart, kstop, jstart, jstop, istart, istop) {
     // RHO already includes a factor of gdet!
+    #if ALLMODELS
+    for (int idx = KEL0; idx < NVAR ; idx++) {
+      flux[idx][k][j][i] = flux[RHO][k][j][i]*S->P[idx][k][j][i];
+    }
+    #elif
     flux[KEL][k][j][i] = flux[RHO][k][j][i]*S->P[KEL][k][j][i];
+    #endif
     flux[KTOT][k][j][i] = flux[RHO][k][j][i]*S->P[KTOT][k][j][i];
   }
 #endif

--- a/core/u_to_p.c
+++ b/core/u_to_p.c
@@ -189,7 +189,13 @@ int U_to_P(struct GridGeom *G, struct FluidState *S, int i, int j, int k,
   S->P[U3][k][j][i] = (gamma/(W + Bsq))*(Qtcon[3] + QdB*Bcon[3]/W);
 
 #if ELECTRONS
+#if ALLMODELS
+  for (int idx = KEL0; idx < NVAR ; idx++) {
+    S->P[idx][k][j][i] = S->U[idx][k][j][i]/S->U[RHO][k][j][i];
+  }
+#elif
   S->P[KEL][k][j][i] = S->U[KEL][k][j][i]/S->U[RHO][k][j][i];
+#endif
   S->P[KTOT][k][j][i] = S->U[KTOT][k][j][i]/S->U[RHO][k][j][i];
 #endif // ELECTRONS
 

--- a/core/u_to_p.c
+++ b/core/u_to_p.c
@@ -189,13 +189,9 @@ int U_to_P(struct GridGeom *G, struct FluidState *S, int i, int j, int k,
   S->P[U3][k][j][i] = (gamma/(W + Bsq))*(Qtcon[3] + QdB*Bcon[3]/W);
 
 #if ELECTRONS
-#if ALLMODELS
   for (int idx = KEL0; idx < NVAR ; idx++) {
     S->P[idx][k][j][i] = S->U[idx][k][j][i]/S->U[RHO][k][j][i];
   }
-#elif
-  S->P[KEL][k][j][i] = S->U[KEL][k][j][i]/S->U[RHO][k][j][i];
-#endif
   S->P[KTOT][k][j][i] = S->U[KTOT][k][j][i]/S->U[RHO][k][j][i];
 #endif // ELECTRONS
 

--- a/prob/torus/parameters.h
+++ b/prob/torus/parameters.h
@@ -37,6 +37,7 @@
  *   BETA_HEAT         - (0,1) BETA-DEPENDENT HEATING
  */
 #define ELECTRONS           1
+#define ALLMODELS           1   // Flag for enabling all models
 #define SUPPRESS_HIGHB_HEAT 1
 #define BETA_HEAT           1
 


### PR DESCRIPTION
Touched up the [PR](https://github.com/AFD-Illinois/iharm3d/pull/37) by @blancocd.

What's new:

- Implements multiple electron-heating models - Kawazura (2019), Werner (2016), Rowan (2017) and Sharma (2007). The`ELECTRONS` flag in `parameters.h` runs the Kawazura model by default. Setting `ALLMODELS` to `1` heats electrons independently according to the four models mentioned above. NOTE: If all electron models are simulated, there will a total of `13` primitives: `RHO`, `UU`, `U1`, `U2`, `U3`, `B1`, `B2`, `B3`, `KTOT`, `KEL0`, `KEL1`, `KEL2`, `KEL3` where `KEL#` stands for electron entropy and `0, 1, 2, 3` => `KAWAZURA, WERNER, ROWAN, SHARMA` respectively.
- Equations are cited for the formulae used to partition total dissipation into heating electrons (and ions).
- `HOWES` model omitted