### PR TITLE
Default to a single MPI process for all problems

### DIFF
--- a/prob/bondi/parameters.h
+++ b/prob/bondi/parameters.h
@@ -13,8 +13,8 @@
 
 /* MPI DECOMPOSITION */
 /* Careful NXCPU < NXTOT!! */
-#define N1CPU 2
-#define N2CPU 2
+#define N1CPU 1
+#define N2CPU 1
 #define N3CPU 1
 
 /* METRIC

--- a/prob/mad/parameters.h
+++ b/prob/mad/parameters.h
@@ -14,8 +14,8 @@
 /* MPI DECOMPOSITION */
 /* COUNTERINTUITIVE: Split N3, N2, N1 order to keep k smaller than i,j*/
 #define N1CPU 1
-#define N2CPU 2
-#define N3CPU 2
+#define N2CPU 1
+#define N3CPU 1
 
 /* METRIC
  *   MINKOWSKI, MKS

--- a/prob/mhdmodes/parameters.h
+++ b/prob/mhdmodes/parameters.h
@@ -1,21 +1,21 @@
-/******************************************************************************  
- *                                                                            *  
- * PARAMETERS.H                                                               *  
- *                                                                            *  
- * PROBLEM-SPECIFIC CHOICES                                                   *  
- *                                                                            *  
+/******************************************************************************
+ *                                                                            *
+ * PARAMETERS.H                                                               *
+ *                                                                            *
+ * PROBLEM-SPECIFIC CHOICES                                                   *
+ *                                                                            *
  ******************************************************************************/
 
 /* GLOBAL RESOLUTION */
 #define N1TOT 64
 #define N2TOT 64
-#define N3TOT 64
+#define N3TOT 1
 
 /* MPI DECOMPOSITION */
 /* DECOMPOSE IN N3 FIRST! Small leading array sizes for linear access */
-#define N1CPU 2
-#define N2CPU 2
-#define N3CPU 4
+#define N1CPU 1
+#define N2CPU 1
+#define N3CPU 1
 
 /* METRIC
  *   MINKOWSKI, MKS


### PR DESCRIPTION
This has now proven an issue for both reviewers of the iharm3D paper, and understandably so as it's maddeningly counter-intuitive.  Better to default to the configurations people will run first, not what's useful for stress-testing.

The tests already set the number of MPI processes for themselves in most cases, but it will take a bit to verify that this doesn't break the automated testing in the 'dev' branch.